### PR TITLE
Update ScalaCheck version, so wootModelJS/test runs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ lazy val wootModel = crossProject
     name := "woot-model",
     libraryDependencies ++= Seq(
       "com.lihaoyi"    %%% "upickle"    % "0.2.8",
-      "org.scalacheck" %%% "scalacheck" % "1.12.2" % "test"
+      "org.scalacheck" %%% "scalacheck" % "1.12.5" % "test"
     )
   )
   .jsSettings(


### PR DESCRIPTION
Fixes #5 

BTW, the default JS environment takes about 7 minutes to run on my laptop.  Probably won't recommend anyone runs it.
